### PR TITLE
Implement ColorSelectModalRect

### DIFF
--- a/cmd/colorpicker-popup/main.go
+++ b/cmd/colorpicker-popup/main.go
@@ -27,23 +27,23 @@ func main() {
 
 func createContainer(w fyne.Window) fyne.CanvasObject {
 	var current color.Color
+	current = defaultColor
 
-	displayColor := newDisplayColor()
-
+	simpleDisplayColor := newSimpleDisplayColor()
 	picker := colorpicker.New(200, colorpicker.StyleDefault)
 	picker.SetOnChanged(func(c color.Color) {
 		current = c
-		displayColor.setColor(current)
+		simpleDisplayColor.setColor(current)
 	})
 	content := fyne.NewContainer(picker)
-
 	button := widget.NewButton("Open color picker", func() {
 		picker.SetColor(current)
 		dialog.ShowCustom("Select color", "OK", content, w)
 	})
+	simpleDisplayColor.setColor(current)
 
-	current = defaultColor
-	displayColor.setColor(current)
+	tappableDisplayColor := newTappableDisplayColor(w)
+	tappableDisplayColor.setColor(current)
 
 	return fyne.NewContainerWithLayout(
 		layout.NewHBoxLayout(),
@@ -52,12 +52,20 @@ func createContainer(w fyne.Window) fyne.CanvasObject {
 			layout.NewVBoxLayout(),
 			layout.NewSpacer(),
 			button,
-			layout.NewSpacer(),
 			fyne.NewContainerWithLayout(
 				layout.NewHBoxLayout(),
 				layout.NewSpacer(),
-				displayColor.label,
-				displayColor.rect,
+				simpleDisplayColor.label,
+				simpleDisplayColor.rect,
+				layout.NewSpacer(),
+			),
+			layout.NewSpacer(),
+			widget.NewLabel("Or tap rectangle"),
+			fyne.NewContainerWithLayout(
+				layout.NewHBoxLayout(),
+				layout.NewSpacer(),
+				tappableDisplayColor.label,
+				tappableDisplayColor.rect,
 				layout.NewSpacer(),
 			),
 			layout.NewSpacer(),
@@ -66,25 +74,45 @@ func createContainer(w fyne.Window) fyne.CanvasObject {
 	)
 }
 
-type displayColor struct {
+type simpleDisplayColor struct {
 	label *widget.Label
 	rect  *canvas.Rectangle
 }
 
-func newDisplayColor() *displayColor {
+func newSimpleDisplayColor() *simpleDisplayColor {
 	selectColorCode := widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{Monospace: true})
 	selectColorRect := &canvas.Rectangle{}
 	selectColorRect.SetMinSize(fyne.NewSize(30, 20))
-	return &displayColor{
+	return &simpleDisplayColor{
 		label: selectColorCode,
 		rect:  selectColorRect,
 	}
 }
 
-func (c *displayColor) setColor(clr color.Color) {
+func (c *simpleDisplayColor) setColor(clr color.Color) {
 	c.label.SetText(hexColorString(clr))
 	c.rect.FillColor = clr
 	c.rect.Refresh()
+}
+
+type tappableDisplayColor struct {
+	label *widget.Label
+	rect  colorpicker.PickerOpenWidget
+}
+
+func newTappableDisplayColor(w fyne.Window) *tappableDisplayColor {
+	selectColorCode := widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{Monospace: true})
+	selectColorRect := colorpicker.NewColorSelectModalRect(w, fyne.NewSize(30, 20), defaultColor)
+	d := &tappableDisplayColor{
+		label: selectColorCode,
+		rect:  selectColorRect,
+	}
+	selectColorRect.SetOnChange(d.setColor)
+	return d
+}
+
+func (c *tappableDisplayColor) setColor(clr color.Color) {
+	c.label.SetText(hexColorString(clr))
 }
 
 func hexColorString(c color.Color) string {

--- a/rect.go
+++ b/rect.go
@@ -10,6 +10,10 @@ import (
 	"fyne.io/fyne/widget"
 )
 
+const (
+	colorSelectModalPickerDefaultSize = 200
+)
+
 // PickerOpenWidget represents a widget that can open a color picker.
 type PickerOpenWidget interface {
 	fyne.CanvasObject
@@ -46,7 +50,7 @@ func (r *colorSelectModalRect) SetPickerStyle(s PickerStyle) {
 }
 
 func (r *colorSelectModalRect) tapped(e *fyne.PointEvent) {
-	picker := New(200, r.pickerStyle)
+	picker := New(colorSelectModalPickerDefaultSize, r.pickerStyle)
 	picker.SetColor(r.color())
 	picker.SetOnChanged(func(c color.Color) {
 		if r.onChange != nil {

--- a/rect.go
+++ b/rect.go
@@ -1,0 +1,133 @@
+package colorpicker
+
+import (
+	"image/color"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/dialog"
+	"fyne.io/fyne/theme"
+	"fyne.io/fyne/widget"
+)
+
+// PickerOpenWidget represents a widget that can open a color picker.
+type PickerOpenWidget interface {
+	fyne.CanvasObject
+
+	SetOnChange(f func(color.Color))
+	SetPickerStyle(s PickerStyle)
+}
+
+type colorSelectModalRect struct {
+	*tappableRect
+	parent      fyne.Window
+	onChange    func(color.Color)
+	pickerStyle PickerStyle
+}
+
+// NewColorSelectModalRect returns a rectangle that can be tapped to open a color picker modal.
+func NewColorSelectModalRect(parent fyne.Window, minSize fyne.Size, defalutColor color.Color) PickerOpenWidget {
+	rect := &colorSelectModalRect{
+		tappableRect: newTappableRect(defalutColor),
+		parent:       parent,
+		pickerStyle:  StyleDefault,
+	}
+	rect.tappableRect.tapped = rect.tapped
+	rect.tappableRect.SetMinSize(minSize)
+	return rect
+}
+
+func (r *colorSelectModalRect) SetOnChange(f func(color.Color)) {
+	r.onChange = f
+}
+
+func (r *colorSelectModalRect) SetPickerStyle(s PickerStyle) {
+	r.pickerStyle = s
+}
+
+func (r *colorSelectModalRect) tapped(e *fyne.PointEvent) {
+	picker := New(200, r.pickerStyle)
+	picker.SetColor(r.color())
+	picker.SetOnChanged(func(c color.Color) {
+		if r.onChange != nil {
+			r.onChange(c)
+		}
+		r.setColor(c)
+	})
+
+	dialog.ShowCustom("Select color", "OK", fyne.NewContainer(picker), r.parent)
+}
+
+type tappableRect struct {
+	widget.BaseWidget
+	rect   *canvas.Rectangle
+	tapped func(*fyne.PointEvent)
+}
+
+func newTappableRect(fillColor color.Color) *tappableRect {
+	r := &tappableRect{
+		rect: &canvas.Rectangle{
+			// Note: Stroke does not work as expected...
+			// StrokeColor: color.RGBA{255, 255, 255, 255},
+			// StrokeWidth: 2,
+			FillColor: fillColor,
+		},
+	}
+	r.ExtendBaseWidget(r)
+	return r
+}
+
+func (r *tappableRect) color() color.Color {
+	return r.rect.FillColor
+}
+
+func (r *tappableRect) setColor(c color.Color) {
+	r.rect.FillColor = c
+	r.Refresh()
+}
+
+func (r *tappableRect) CreateRenderer() fyne.WidgetRenderer {
+	return &tappableRectRenderer{rect: r.rect}
+}
+
+func (r *tappableRect) SetMinSize(size fyne.Size) {
+	r.rect.SetMinSize(size)
+}
+
+func (r *tappableRect) MinSize() fyne.Size {
+	return r.rect.MinSize()
+}
+
+func (r *tappableRect) Tapped(e *fyne.PointEvent) {
+	if r.tapped != nil {
+		r.tapped(e)
+	}
+}
+
+func (r *tappableRect) TappedSecondary(*fyne.PointEvent) {}
+
+type tappableRectRenderer struct {
+	rect *canvas.Rectangle
+}
+
+func (r *tappableRectRenderer) Layout(size fyne.Size) {
+	r.rect.Resize(size)
+}
+
+func (r *tappableRectRenderer) MinSize() fyne.Size {
+	return r.rect.MinSize()
+}
+
+func (r *tappableRectRenderer) Refresh() {
+	canvas.Refresh(r.rect)
+}
+
+func (r *tappableRectRenderer) BackgroundColor() color.Color {
+	return theme.BackgroundColor()
+}
+
+func (r *tappableRectRenderer) Objects() []fyne.CanvasObject {
+	return []fyne.CanvasObject{r.rect}
+}
+
+func (r *tappableRectRenderer) Destroy() {}


### PR DESCRIPTION
#6 

- Newly defined rectangle widget that can be tapped to open color picker modal.
- Update sample app (colorpicker-popup) to use this.